### PR TITLE
Fix: Update ONNX model ID and loading parameters

### DIFF
--- a/app/generator.py
+++ b/app/generator.py
@@ -49,17 +49,17 @@ def load_model():
         else:
             logging.info("Hugging Face Hub token not found. Attempting anonymous download.")
 
-        logging.info("Attempting to load ONNX model 'stabilityai/stable-diffusion-2-1'...")
+        logging.info("Attempting to load ONNX model 'optimum/stable-diffusion-2-1-onnx'...")
         pipe = OnnxStableDiffusionPipeline.from_pretrained(
-            "stabilityai/stable-diffusion-2-1",  # Updated ONNX model ID
+            "optimum/stable-diffusion-2-1-onnx",  # Changed to dedicated ONNX model ID
             provider="CPUExecutionProvider",   # ✅ CPU-only
-            use_auth_token=auth_token if auth_token else None,
-            revision="onnx" # Explicitly specify ONNX revision
+            use_auth_token=auth_token if auth_token else None
+            # revision="onnx" removed for now
         )
         model_loaded = True
-        logging.info("ONNX model 'stabilityai/stable-diffusion-onnx' loaded successfully.")
+        logging.info("ONNX model 'optimum/stable-diffusion-2-1-onnx' loaded successfully.")
     except Exception as e:
-        logging.error(f"ONNX model 'stabilityai/stable-diffusion-2-1' failed to load: {e}")
+        logging.error(f"ONNX model 'optimum/stable-diffusion-2-1-onnx' failed to load: {e}")
         logging.error("This could be due to network issues, incorrect model ID, missing ONNX runtime dependencies, or issues with the ONNX model files themselves.")
         logging.error("Ensure 'onnxruntime' is installed and functional.")
         model_loaded = False


### PR DESCRIPTION
Changed the ONNX model ID from 'stabilityai/stable-diffusion-2-1' with 'revision="onnx"' to 'optimum/stable-diffusion-2-1-onnx' without the revision parameter.

This attempts to fix the model loading issue where the previous model ID and revision combination was not found on the Hugging Face Hub. The 'optimum' namespace usually provides pre-converted ONNX models compatible with the Diffusers library.